### PR TITLE
Add biometric authentication flow for returning users

### DIFF
--- a/app/auth/biometric-prompt.tsx
+++ b/app/auth/biometric-prompt.tsx
@@ -1,0 +1,2 @@
+import BiometricPromptScreen from '../../screens/BiometricPromptScreen';
+export default BiometricPromptScreen;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-haptics": "~14.0.1",
         "expo-image-picker": "~16.0.6",
         "expo-linking": "~7.0.5",
+        "expo-local-authentication": "~15.0.2",
         "expo-location": "~18.0.10",
         "expo-router": "~4.0.20",
         "expo-secure-store": "~14.0.1",
@@ -8139,6 +8140,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-15.0.2.tgz",
+      "integrity": "sha512-v7TOfovuivGWffA8B0FudEas+njMKTrjhaPpJYLASiTLTP3zUYqtumNgZ9pkaDB6Cagq0+DeNH39AI8tdEBUkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-location": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "expo-image-picker": "~16.0.6"
+    "expo-image-picker": "~16.0.6",
+    "expo-local-authentication": "~15.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/BiometricPromptScreen.tsx
+++ b/screens/BiometricPromptScreen.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, Text, ActivityIndicator } from 'react-native';
+import * as LocalAuthentication from 'expo-local-authentication';
+import { useRouter } from 'expo-router';
+import { useTheme } from '../context/ThemeContext';
+import Dialog from '../components/ui/alerts/Dialog';
+import { spacing } from '../constants/spacing';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function BiometricPrompt() {
+  const theme = useTheme();
+  const router = useRouter();
+  const [errorVisible, setErrorVisible] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(true);
+
+  useEffect(() => {
+    const authenticate = async () => {
+      try {
+        const hasHardware = await LocalAuthentication.hasHardwareAsync();
+        const isEnrolled = await LocalAuthentication.isEnrolledAsync();
+
+        if (!hasHardware || !isEnrolled) {
+          setErrorVisible(true);
+          return;
+        }
+
+        const result = await LocalAuthentication.authenticateAsync({
+          promptMessage: 'Authenticate to Login',
+          fallbackLabel: 'Use PIN',
+          cancelLabel: 'Cancel',
+        });
+
+        if (result.success) {
+          router.replace('/(tabs)');
+        } else {
+          setErrorVisible(true);
+        }
+      } catch (error) {
+        console.log('❌ Biometric auth error:', error);
+        setErrorVisible(true);
+      } finally {
+        setIsAuthenticating(false);
+      }
+    };
+
+    authenticate();
+  }, []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <Ionicons
+        name="lock-closed-outline"
+        size={64}
+        color={theme.text}
+        style={styles.icon}
+      />
+      <Text style={[styles.title, { color: theme.text }]}>
+        Verifying your identity...
+      </Text>
+      {isAuthenticating && <ActivityIndicator size="large" color={theme.tint} />}
+      <Dialog
+        visible={errorVisible}
+        message="Could not verify your identity. Please try again or log in manually."
+        type="error"
+        onClose={() => router.replace('/auth/login')}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.lg,
+  },
+  icon: {
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '500',
+    marginBottom: spacing.md,
+    textAlign: 'center',
+  },
+});

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -18,7 +18,7 @@ import { spacing } from '../constants/spacing';
 import { useRouter } from 'expo-router';
 import EditForm from '../components/ui/forms/EditForm';
 import UserProfileInfo from '../components/ui/cards/UserProfileCard';
-import { Feather } from '@expo/vector-icons'; // 👈 íconos
+import { Feather } from '@expo/vector-icons';
 
 export default function ProfileScreen() {
   const theme = useTheme();

--- a/screens/StartupScreen.tsx
+++ b/screens/StartupScreen.tsx
@@ -20,7 +20,8 @@ export default function StartupScreen() {
         const now = Date.now();
 
         if (user && now - lastLogin < twoWeeksInMs) {
-          router.replace('/(tabs)');
+          router.replace('/auth/biometric-prompt');
+
         } else {
           router.replace('/auth/login');
         }


### PR DESCRIPTION
# Add biometric authentication flow for returning users

This PR introduces a biometric authentication step for users with active sessions. If the user has recently logged in and has biometrics enrolled, they are prompted to authenticate using Face ID or Touch ID before accessing the app. The fallback to device passcode is enabled during development via Expo Go.

## What’s included

- ✅ New screen: `BiometricPromptScreen.tsx` in `screens/`
- ✅ Route export: `app/auth/biometric-prompt.tsx`
- ✅ Session check logic in `StartupScreen.tsx` updated to trigger biometric prompt
- ✅ Biometric authentication logic using `expo-local-authentication`
- ✅ Error handling and fallback messaging via custom `Dialog` component

> Note: On iOS, biometric prompts (Face ID / Touch ID) are only available in real builds (via EAS) and not in Expo Go.
